### PR TITLE
Autoload ranger-override-dired

### DIFF
--- a/ranger.el
+++ b/ranger.el
@@ -230,6 +230,7 @@ Outputs a string that will show up on the header-line."
                 (const :tag "Roman numerals" :value roman)
                 (const :tag "Numbers only" :value numbers)))
 
+;;;###autoload
 (defcustom ranger-override-dired nil
   "When non-nil, load `deer' whenever dired is loaded.")
 


### PR DESCRIPTION
This bug was introduced by #75. Since the variable is read by autoloaded code it must also be defined by autoloaded code. I tested and it worked for me.
