### PR TITLE
Add missing with-eval-after-load

### DIFF
--- a/ranger.el
+++ b/ranger.el
@@ -501,7 +501,8 @@ to not replace existing value."
 
 ;;;###autoload
 (when ranger-key
-  (define-key dired-mode-map ranger-key 'ranger-mode))
+  (with-eval-after-load 'dired
+    (define-key dired-mode-map ranger-key 'ranger-mode)))
 
 (defun ranger-define-additional-maps (&optional mode)
   "Define additional mappings for ranger-mode that can't simply be in the defvar (depend on packages)."


### PR DESCRIPTION
Since this piece of code is marked autoload, it might run before `dired` is loaded. This seems to happen on Spacemacs master, which causes an error that interrups evaluation of the rest of ranger's autoloads.
