### PR TITLE
Fix the handling of custom ranger-key

### DIFF
--- a/ranger.el
+++ b/ranger.el
@@ -504,8 +504,9 @@ to not replace existing value."
 
 ;;;###autoload
 (when ranger-key
-  (with-eval-after-load 'dired
-    (define-key dired-mode-map ranger-key 'deer)))
+  (add-hook 'dired-mode-hook
+            (defun ranger-set-dired-key ()
+                (define-key dired-mode-map ranger-key 'deer))))
 
 (defun ranger-define-additional-maps (&optional mode)
   "Define additional mappings for ranger-mode that can't simply be in the defvar (depend on packages)."


### PR DESCRIPTION
`with-eval-after-load` was evalutaing the variable's value too soon and
the default value was used regardless of the custom value.
