### PR TITLE
Fixed cursor vanishing bug on previewed files

### DIFF
--- a/ranger.el
+++ b/ranger.el
@@ -1844,7 +1844,6 @@ win configs: "
               )
             (ranger--message "Modifying preview: %s" preview-buffer)
             (with-current-buffer preview-buffer
-              (setq-local cursor-type nil)
               (setq mouse-1-click-follows-link nil)
               (local-set-key (kbd  "<mouse-1>") #'(lambda ()
                                                     (interactive)


### PR DESCRIPTION
How to reproduce the bug:
1. Open a .el file
2. Run ranger
3. Press z+i to trigger a preview
4. Press enter to re-open the file
5. The cursor has vanished! (cursor comes back if you eval (setq cursor-type t))

The downside of this one line change is that the cursor is now visible in preview mode but I think the vanishing cursor is a bigger problem.
