### PR TITLE
Fix void variable error when getting available tabs.

### DIFF
--- a/ranger.el
+++ b/ranger.el
@@ -950,8 +950,10 @@ the idle timer fires are ignored."
           (r--akeys ranger-t-alist))
          (total-tabs
           (number-sequence 1 ranger-max-tabs))
+         (test-func
+          (lambda (tab) (member tab tabs)))
          (available-tabs
-          (cl-remove-if '(lambda (tab) (member tab tabs)) total-tabs)))
+          (cl-remove-if test-func total-tabs)))
     available-tabs))
 
 (defun ranger-new-tab (&optional index no-refresh)


### PR DESCRIPTION
Without this change I' running into the issue of `tabs` being a void variable due to lexical binding.