### PR TITLE
ranger-create-mark: cancel upon "<escape>" (don't bookmark it)

### DIFF
--- a/ranger.el
+++ b/ranger.el
@@ -1086,9 +1086,10 @@ the idle timer fires are ignored."
 ranger-`CHAR'."
   (interactive "cm-")
   (let ((mark-letter (char-to-string mark)))
-    (bookmark-set (concat "ranger-" mark-letter))
-    (message "Bookmarked directory %s as `ranger-%s'"
-             default-directory mark-letter)))
+    (unless (string= mark-letter "")
+      (bookmark-set (concat "ranger-" mark-letter))
+      (message "Bookmarked directory %s as `ranger-%s'"
+               default-directory mark-letter))))
 
 (defun ranger-remove-mark ()
   (interactive)


### PR DESCRIPTION
* bookmarking a literal `"<escape>"` is surprising, fairly confusing, and as far as I'm aware not particularly useful

* this is also consistent with how the original ranger behaves (it cancels the marking action)