### PR TITLE
Preserve the ability to click links after invoking `ranger`

### DIFF
--- a/ranger.el
+++ b/ranger.el
@@ -1760,8 +1760,7 @@ R   : ranger . el location
 (defun ranger-sub-window-setup ()
   "Parent window options."
   ;; allow mouse click to jump to that directory
-  (make-local-variable 'mouse-1-click-follows-link)
-  (setq mouse-1-click-follows-link nil)
+  (setq-local mouse-1-click-follows-link nil)
   (local-set-key (kbd  "<mouse-1>") 'ranger-find-file)
   ;; set header-line
   (when ranger-modify-header
@@ -2039,7 +2038,7 @@ is set, show literally instead of actual buffer."
               )
             (with-current-buffer preview-buffer
               (setq-local cursor-type nil)
-              (setq mouse-1-click-follows-link nil)
+              (setq-local mouse-1-click-follows-link nil)
               (local-set-key (kbd  "<mouse-1>") #'(lambda ()
                                                     (interactive)
                                                     (select-window ranger-window)


### PR DESCRIPTION
Sets `mouse-1-click-follows-link` locally instead of globally.

The previous behavior was to overwrite the global value--after invoking `ranger`, `<mouse-1>` would not follow links in help buffers.

I haven't investigated very thoroughly, but this appears to preserve all of the original `ranger` functionality that I know about, while leaving the global value of `mouse-1-click-follows-link` alone.