### PR TITLE
Fix ranger-next/prev-parent when there is no parent

### DIFF
--- a/ranger.el
+++ b/ranger.el
@@ -1860,24 +1860,30 @@ slot)."
     (add-to-list 'ranger-parent-windows parent-window)))
 
 (defun ranger-next-parent ()
-  "Move up in parent directory"
+  "Move down in parent directory"
   (interactive)
-  (with-current-buffer (car ranger-parent-buffers)
-    (dired-next-line 1)
-    (let ((curfile (dired-get-filename nil t)))
-      (if (file-directory-p curfile)
-          (ranger-find-file curfile)
-        (dired-next-line -1)))))
+  (let ((parent (car ranger-parent-buffers)))
+    (if parent
+        (with-current-buffer parent
+          (dired-next-line 1)
+          (let ((curfile (dired-get-filename nil t)))
+            (if (file-directory-p curfile)
+                (ranger-find-file curfile)
+              (dired-next-line -1))))
+      (message "No parent directory."))))
 
 (defun ranger-prev-parent ()
   "Move up in parent directory"
   (interactive)
-  (with-current-buffer (car ranger-parent-buffers)
-    (dired-next-line -1)
-    (let ((curfile (dired-get-filename nil t)))
-      (if (file-directory-p curfile)
-          (ranger-find-file curfile)
-        (dired-next-line 1)))))
+  (let ((parent (car ranger-parent-buffers)))
+    (if parent
+        (with-current-buffer (car ranger-parent-buffers)
+          (dired-next-line -1)
+          (let ((curfile (dired-get-filename nil t)))
+            (if (file-directory-p curfile)
+                (ranger-find-file curfile)
+              (dired-next-line 1))))
+      (message "No parent directory."))))
 
 
 ;; window creation subroutines


### PR DESCRIPTION
### Fix `ranger-next-parent`/`ranger-prev-parent` when there is no parent

In a deer session or in a ranger session in the root directory, there is no parent directory.  `ranger-next-parent` and `ranger-prev-parent` do not check for this condition.  Consequently, pressing `[` or `]` would cause the following error in these contexts:

    Wrong type argument: stringp, nil

This commit adds the needed check.

* `ranger.el` (`ranger-next-parent`): Fix doc string.
(`ranger-next-parent`, `ranger-prev-parent`): Check if there is a parent directory buffer before trying to use it, proceed normally if there is, and print a message if there is not.