### PR TITLE
fix: Invalid function: (delete-window)

### DIFF
--- a/ranger.el
+++ b/ranger.el
@@ -2959,8 +2959,9 @@ properly provides the modeline in dired mode. "
   (interactive)
   ;; don't kill ranger buffer if open somewhere else
   (if (> (length (get-buffer-window-list)) 1)
-      ((delete-window)
-       (delete-window ranger-preview-window))
+      (progn
+        (delete-window)
+        (delete-window ranger-preview-window))
     (ranger-revert)))
 
 (defun ranger-to-dired ()


### PR DESCRIPTION
To reproduce the situation:

1. `zi` to enable full-text previews
2. `l` to the file `ranger.el`

Then there will be error as below:

```
File opened, exiting ranger
if: Invalid function: (delete-window)
```