### PR TITLE
Fix 'ranger-revert' not killing buffers behavior:

### DIFF
--- a/ranger.el
+++ b/ranger.el
@@ -2649,8 +2649,9 @@ fraction of the total frame size"
 
 (defun ranger-frame-exists-p ()
   "Test if any ranger-frames are live."
-  (mapcar 'frame-live-p
-          (r--akeys ranger-f-alist)))
+  (member t
+          (mapcar 'frame-live-p
+                  (r--akeys ranger-f-alist))))
 
 (defun ranger-kill-buffers-without-window ()
   "Will kill all ranger buffers that are not displayed in any window."


### PR DESCRIPTION
- during the "Reverting all buffers" stage of 'ranger-revert' function 'ranger-frame-exists-p' predicate returned '(nil)' (which is evaluated to "true" in Lisp) but 'nil' was expected.

The behavior was noticed during testing quit ('q' keybinding in ranger's mode map) function.
Steps to reproduce:
1. Open any directory with ranger.
2. Press 'q'.

Expected:
1. All ranger related buffers are killed (with 'ranger-cleanup-on-disable' set to non-nil).

Actual:
1. All ranger related buffers stay alive.